### PR TITLE
Add consumer and deserialise avro records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+# IntelliJ files
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,15 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
+        <ch-kafka.version>1.4.2</ch-kafka.version>
+        <structured-logging.version>1.9.12</structured-logging.version>
+        <kafka-models.version>1.0.28</kafka-models.version>
+        <private-api-sdk-java.version>2.0.174</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+
+        <!-- Tests -->
+        <assertj-core.version>3.22.0</assertj-core.version>
+        <test-containers.version>1.16.3</test-containers.version>
 
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
@@ -52,11 +61,59 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>kafka-models</artifactId>
+            <version>${kafka-models.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>ch-kafka</artifactId>
+            <version>${ch-kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>structured-logging</artifactId>
+            <version>${structured-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-manager-java-library</artifactId>
+            <version>${api-sdk-manager-java-library.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${test-containers.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/main/java/uk/gov/companieshouse/psc/delta/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/config/ApplicationConfig.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.psc.delta.config;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+@Configuration
+public class ApplicationConfig implements WebMvcConfigurer {
+
+    @Bean
+    SerializerFactory serializerFactory() {
+        return new SerializerFactory();
+    }
+
+    @Bean
+    EnvironmentReader environmentReader() {
+        return new EnvironmentReaderImpl();
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public InternalApiClient internalApiClient() {
+        return ApiSdkManager.getPrivateSDK();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/config/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/config/KafkaConfig.java
@@ -1,0 +1,102 @@
+package uk.gov.companieshouse.psc.delta.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.psc.delta.serialization.ChsDeltaDeserializer;
+import uk.gov.companieshouse.psc.delta.serialization.ChsDeltaSerializer;
+
+@Configuration
+@EnableKafka
+@Profile("!test")
+public class KafkaConfig {
+
+    private final ChsDeltaDeserializer chsDeltaDeserializer;
+    private final ChsDeltaSerializer chsDeltaSerializer;
+
+    private final String bootstrapServers;
+
+    /**
+     * Constructor.
+     */
+    public KafkaConfig(ChsDeltaDeserializer chsDeltaDeserializer,
+                       ChsDeltaSerializer chsDeltaSerializer,
+                       @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.chsDeltaDeserializer = chsDeltaDeserializer;
+        this.chsDeltaSerializer = chsDeltaSerializer;
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    /**
+     * Kafka Consumer Factory.
+     */
+    @Bean
+    public ConsumerFactory<String, ChsDelta> kafkaConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(chsDeltaDeserializer));
+    }
+
+    /**
+     * Kafka Producer Factory.
+     */
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ChsDeltaSerializer.class);
+        return new DefaultKafkaProducerFactory<>(
+                props, new StringSerializer(), chsDeltaSerializer);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    /**
+     * Kafka Listener Container Factory.
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ChsDelta> listenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChsDelta> factory
+                = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(kafkaConsumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+
+        return factory;
+    }
+
+    private Map<String, Object> consumerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, ChsDeltaDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+
+        return props;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/config/LoggingConfig.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/config/LoggingConfig.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.psc.delta.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Configuration class for logging.
+ */
+@Configuration
+public class LoggingConfig {
+
+    @Value("${logger.namespace}")
+    private String loggerNamespace;
+
+    private static Logger staticLogger;
+
+    /**
+     * Main application logger with component specific namespace.
+     *
+     * @return the {@link LoggerFactory} for the specified namespace
+     */
+    @Bean
+    public Logger logger() {
+        Logger loggerBean = LoggerFactory.getLogger(loggerNamespace);
+        staticLogger = loggerBean;
+        return loggerBean;
+    }
+
+
+    public static Logger getLogger() {
+        return staticLogger;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/consumer/PscDeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/consumer/PscDeltaConsumer.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.psc.delta.consumer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.DltStrategy;
+import org.springframework.kafka.retrytopic.FixedDelayStrategy;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+
+@Component
+public class PscDeltaConsumer {
+
+    private final Logger logger;
+    public final KafkaTemplate<String, Object> kafkaTemplate;
+
+    /**
+     * Default constructor.
+     */
+    @Autowired
+    public PscDeltaConsumer(Logger logger, KafkaTemplate<String, Object> kafkaTemplate) {
+        this.logger = logger;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    /**
+     * Receives Main topic messages.
+     */
+    @RetryableTopic(attempts = "${pscs.delta.retry-attempts}",
+            backoff = @Backoff(delayExpression = "${pscs.delta.backoff-delay}"),
+            fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC,
+            dltTopicSuffix = "-error",
+            dltStrategy = DltStrategy.FAIL_ON_ERROR,
+            autoCreateTopics = "false",
+            exclude = NonRetryableErrorException.class)
+    @KafkaListener(topics = "${pscs.delta.topic}",
+            groupId = "${pscs.delta.group-id}",
+            containerFactory = "listenerContainerFactory")
+    public void receiveMainMessages(Message<ChsDelta> chsDeltaMessage,
+                                    @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+        logger.info("A new message read from " + topic + " topic with payload: "
+                    + chsDeltaMessage.getPayload());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/exception/NonRetryableErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/exception/NonRetryableErrorException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.psc.delta.exception;
+
+public class NonRetryableErrorException extends RuntimeException {
+    public NonRetryableErrorException(Exception ex) {
+        super(ex);
+    }
+
+    public NonRetryableErrorException(String message) {
+        super(message);
+    }
+
+    public NonRetryableErrorException(String message, Exception exception) {
+        super(message, exception);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/exception/RetryableErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/exception/RetryableErrorException.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.psc.delta.exception;
+
+public class RetryableErrorException extends RuntimeException {
+    public RetryableErrorException(String message) {
+        super(message);
+    }
+
+    public RetryableErrorException(String message, Exception exception) {
+        super(message, exception);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaDeserializer.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.psc.delta.serialization;
+
+import java.util.Arrays;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+
+@Component
+public class ChsDeltaDeserializer implements Deserializer<ChsDelta> {
+    
+    @Override
+    public ChsDelta deserialize(String topic, byte[] data) {
+        try {
+            Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
+            DatumReader<ChsDelta> reader = new ReflectDatumReader<>(ChsDelta.class);
+            return reader.read(null, decoder);
+        } catch (Exception ex) {
+            throw new NonRetryableErrorException(
+                    "Message data [" + Arrays.toString(data) + "] from topic [" + topic + "] "
+                            + "cannot be deserialized", ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaSerializer.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.psc.delta.serialization;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.common.serialization.Serializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+
+
+@Component
+public class ChsDeltaSerializer implements Serializer<Object> {
+
+    private final Logger logger;
+
+    @Autowired
+    public ChsDeltaSerializer(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public byte[] serialize(String topic, Object payload) {
+        logger.trace("Payload serialised: " + payload);
+
+        try {
+            if (payload == null) {
+                return null;
+            }
+
+            if (payload instanceof byte[]) {
+                return (byte[]) payload;
+            }
+
+            if (payload instanceof ChsDelta) {
+                ChsDelta chsDelta = (ChsDelta) payload;
+                DatumWriter<ChsDelta> writer = new SpecificDatumWriter<>();
+                EncoderFactory encoderFactory = EncoderFactory.get();
+
+                AvroSerializer<ChsDelta> avroSerializer =
+                        new AvroSerializer<>(writer, encoderFactory);
+
+                return avroSerializer.toBinary(chsDelta);
+            }
+
+            return payload.toString().getBytes(StandardCharsets.UTF_8);
+        } catch (Exception ex) {
+            logger.error("Serialization exception while writing to byte array", ex);
+            throw new NonRetryableErrorException(ex);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+server:
+  port: 8081
+
+springfox:
+  documentation:
+    auto-startup: false
+
+spring:
+  kafka:
+    bootstrap-servers: ${DATA_SYNC_KAFKA_BROKER_URL:localhost:9092}
+
+pscs:
+  delta:
+    group-id: psc-delta-consumer
+    topic: ${PSC_DELTA_TOPIC:psc-delta}
+    retry-attempts: ${PSC_DELTA_ATTEMPTS:4}
+    backoff-delay: ${PSC_DELTA_BACKOFF_DELAY:100}
+
+
+logger:
+  namespace: psc-delta-consumer

--- a/src/test/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaDeserializerTest.java
@@ -1,0 +1,43 @@
+package uk.gov.companieshouse.psc.delta.serialization;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class ChsDeltaDeserializerTest {
+
+    @Mock
+    private Logger logger;
+    private ChsDeltaDeserializer deserializer = new ChsDeltaDeserializer();
+
+    @Test
+    void When_deserialize_Expect_ValidChsDeltaObject() {
+        ChsDelta chsDelta = new ChsDelta("data", 1, "context_id",false);
+        byte[] data = encodedData(chsDelta);
+
+        ChsDelta deserializedObject = deserializer.deserialize("", data);
+
+        assertThat(deserializedObject).isEqualTo(chsDelta);
+    }
+
+    @Test
+    void When_deserializeFails_throwsNonRetryableError() {
+        byte[] data = "Invalid message".getBytes();
+        assertThrows(NonRetryableErrorException.class, () -> deserializer.deserialize("", data));
+    }
+
+    private byte[] encodedData(ChsDelta chsDelta){
+        ChsDeltaSerializer serializer = new ChsDeltaSerializer(this.logger);
+        byte[] serialisedData = serializer.serialize("", chsDelta);
+        serializer.close();
+        return serialisedData;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/serialization/ChsDeltaSerializerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.psc.delta.serialization;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class ChsDeltaSerializerTest {
+
+    @Mock
+    private Logger logger;
+    private ChsDeltaSerializer serializer;
+
+    @BeforeEach
+    public void init() {
+        serializer = new ChsDeltaSerializer(logger);
+    }
+
+    @Test
+    void When_serialize_Expect_ValidByteArray() {
+        ChsDelta chsDelta = new ChsDelta("data", 1, "context_id",false);
+        byte[] data = { 0x08, 0x64, 0x61, 0x74, 0x61, 0x02, 0x14, 0x63, 0x6F, 0x6E, 0x74, 0x65, 0x78, 0x74, 0x5F, 0x69, 0x64, 0x0 };
+
+        byte[] serializedObject = serializer.serialize("", chsDelta);
+
+        assertThat(serializedObject).isEqualTo(data);
+    }
+
+    @Test
+    void When_serialize_null_returns_null() {
+        byte[] serialize = serializer.serialize("", null);
+        assertThat(serialize).isNull();
+    }
+
+    @Test
+    void When_serialize_receivesBytes_returnsBytes() {
+        byte[] byteExample = "Example bytes".getBytes();
+        byte[] serialize = serializer.serialize("", byteExample);
+        assertThat(serialize).isEqualTo(byteExample);
+    }
+
+    @Test
+    void When_serialize_receives_blank_object_exception_thrown() {
+        ChsDelta payload = new ChsDelta();
+        assertThrows(NonRetryableErrorException.class, () -> serializer.serialize("",payload));
+    }
+
+}


### PR DESCRIPTION
This PR adds a consumer component configured to listen to kafka topics read from config, as well as serialisers and deserialisers for management of avro records. Configuration classes are added for the application, logging and kafka.
Finally, unit tests are added for the serialiser and deserialiser.

**Resolves:**
- DSND-1501