### PR TITLE
Created mapper and transformer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/psc/delta/mapper/PscMapper.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/mapper/PscMapper.java
@@ -33,7 +33,6 @@ public interface PscMapper {
     @Mapping(target = "externalData.data.links", ignore = true)
     @Mapping(target = "externalData.data.kind", source = "kind", ignore = true)
     @Mapping(target = "externalData.data.ceasedOn", source = "ceasedOn", ignore = true)
-
     @Mapping(target = "externalData.pscId", source = "pscId", ignore = true)
     @Mapping(target = "externalData.data.notifiedOn", source = "notificationDate",
             dateFormat = "yyyyMMdd")

--- a/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientService.java
@@ -18,6 +18,7 @@ public interface ApiClientService {
      */
     ApiResponse<Void> putPscFullRecord(
             final String log,
-            final String consumerId,
+            final String companyId,
+            final String customerId,
             final FullRecordCompanyPSCApi fullRecordCompanyPSCApi);
 }

--- a/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImpl.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.logging.Logger;
 @Service
 public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements ApiClientService {
 
-    @Value("${api.disqualified-officers-data-api-key}")
+    @Value("${api.pscFullRecord-data-api-key}")
     private String chsApiKey;
 
     @Value("${api.api-url}")

--- a/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImpl.java
@@ -52,7 +52,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
     public ApiResponse<Void> putPscFullRecord(String log, String companyId, String customerId, FullRecordCompanyPSCApi fullRecordCompanyPSCApi) {
 
-        final String uri = String.format("/company/%s/persons-with-significant-control/%s", companyId, customerId);
+        final String uri = String.format("/company/%s/persons-with-significant-control/%s/individual", companyId, customerId);
 
         Map<String, Object> logMap = createLogMap(companyId, "PUT", uri);
         logger.infoContext(log, String.format("PUT %s", uri), logMap);

--- a/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImpl.java
@@ -50,11 +50,11 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
         return internalApiClient;
     }
 
-    public ApiResponse<Void> putPscFullRecord(String log, String consumerId, FullRecordCompanyPSCApi fullRecordCompanyPSCApi) {
+    public ApiResponse<Void> putPscFullRecord(String log, String companyId, String customerId, FullRecordCompanyPSCApi fullRecordCompanyPSCApi) {
 
-        final String uri = String.format("/", consumerId);
+        final String uri = String.format("/company/%s/persons-with-significant-control/%s", companyId, customerId);
 
-        Map<String, Object> logMap = createLogMap(consumerId, "PUT", uri);
+        Map<String, Object> logMap = createLogMap(companyId, "PUT", uri);
         logger.infoContext(log, String.format("PUT %s", uri), logMap);
         return executeOp(log, "putPscFullRecord", uri,
                 getApiClient(log).privatePscFullRecordResourceHandler()

--- a/src/main/java/uk/gov/companieshouse/psc/delta/service/api/BaseApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/service/api/BaseApiClientServiceImpl.java
@@ -55,12 +55,13 @@ public abstract class BaseApiClientServiceImpl {
                         "400 BAD_REQUEST response received from psc-data-api";
                 logger.errorContext(logContext, msg, ex, logMap);
                 throw new NonRetryableErrorException(msg, ex);
-            } else if (ex.getStatusCode() == HttpStatus.NOT_FOUND.value()
-                    && operationName.equals("deleteDisqualification")) {
-                String msg =
-                        "404 NOT_FOUND response received from psc-data-api";
-                throw new RetryableErrorException(msg);
             }
+//            else if (ex.getStatusCode() == HttpStatus.NOT_FOUND.value()
+//                    && operationName.equals("deleteDisqualification")) {
+//                String msg =
+//                        "404 NOT_FOUND response received from psc-data-api";
+//                throw new RetryableErrorException(msg);
+//            }
 
             // any other client or server status is retryable
             String msg = "Non-Successful response received from psc-data-api";

--- a/src/main/java/uk/gov/companieshouse/psc/delta/transformer/PscApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/transformer/PscApiTransformer.java
@@ -9,8 +9,6 @@ import org.springframework.stereotype.Component;
 
 import uk.gov.companieshouse.api.delta.Psc;
 import uk.gov.companieshouse.api.delta.PscDelta;
-import uk.gov.companieshouse.api.psc.Data;
-import uk.gov.companieshouse.api.psc.ExternalData;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.api.psc.InternalData;
 import uk.gov.companieshouse.psc.delta.mapper.PscMapper;
@@ -37,18 +35,9 @@ public class PscApiTransformer {
      */
     public FullRecordCompanyPSCApi transform(PscDelta pscDelta) {
 
-        FullRecordCompanyPSCApi fullRecordCompanyPscApi = new FullRecordCompanyPSCApi();
-        ExternalData externalData = new ExternalData();
-        InternalData internalData = new InternalData();
-        Data data = new Data();
-
-        fullRecordCompanyPscApi.setExternalData(externalData);
-        fullRecordCompanyPscApi.setInternalData(internalData);
-        externalData.setData(data);
-
         Psc psc = pscDelta.getPscs().get(0);
 
-        fullRecordCompanyPscApi = pscMapper.mapPscData(psc);
+        FullRecordCompanyPSCApi fullRecordCompanyPscApi = pscMapper.mapPscData(psc);
 
         return parseDeltaAt(fullRecordCompanyPscApi, pscDelta);
     }

--- a/src/test/java/uk/gov/companieshouse/psc/delta/processor/PscDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/processor/PscDeltaProcessorTest.java
@@ -1,0 +1,126 @@
+package uk.gov.companieshouse.psc.delta.processor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.FileCopyUtils;
+import uk.gov.companieshouse.api.delta.Psc;
+import uk.gov.companieshouse.api.delta.PscDelta;
+import uk.gov.companieshouse.api.psc.Data;
+import uk.gov.companieshouse.api.psc.ExternalData;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.psc.delta.service.api.ApiClientService;
+import uk.gov.companieshouse.psc.delta.transformer.PscApiTransformer;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PscDeltaProcessorTest {
+    private PscDeltaProcessor deltaProcessor;
+    @Mock
+    private Logger logger;
+    @Mock
+    private ApiClientService apiClientService;
+    @Mock
+    private PscApiTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        deltaProcessor = new PscDeltaProcessor(logger, apiClientService, transformer);
+    }
+
+    @Test
+    @DisplayName("Transforms a kafka message containing a ChsDelta payload into a PscDelta")
+    void When_ValidChsDeltaMessage_Expect_ValidPscDeltaMapping() throws IOException {
+        Message<ChsDelta> mockChsDeltaMessage = createChsDeltaMessage();
+        PscDelta expectedDelta = createPscDelta();
+        FullRecordCompanyPSCApi apiObject = createFullRecordPsc();
+        when(transformer.transform(expectedDelta)).thenReturn(apiObject);
+
+        deltaProcessor.processDelta(mockChsDeltaMessage);
+
+        verify(transformer).transform(expectedDelta);
+    }
+
+    @Test
+    void When_InvalidChsDeltaMessage_Expect_NonRetryableError() {
+        Message<ChsDelta> mockChsDeltaMessage = createInvalidChsDeltaMessage();
+        assertThrows(NonRetryableErrorException.class, ()->deltaProcessor.processDelta(mockChsDeltaMessage));
+    }
+
+    private Message<ChsDelta> createChsDeltaMessage() throws IOException {
+        InputStreamReader exampleJsonPayload = new InputStreamReader(
+                ClassLoader.getSystemClassLoader().getResourceAsStream("super-secure-psc-delta-example.json"));
+        String data = FileCopyUtils.copyToString(exampleJsonPayload);
+        ChsDelta mockChsDelta = ChsDelta.newBuilder()
+                .setData(data)
+                .setContextId("context_id")
+                .setAttempt(1)
+                .build();
+        return MessageBuilder
+                .withPayload(mockChsDelta)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "test")
+                .setHeader("PSC_DELTA_RETRY_COUNT", 1)
+                .build();
+    }
+
+    public Message<ChsDelta> createInvalidChsDeltaMessage() {
+        ChsDelta mockChsDelta = ChsDelta.newBuilder()
+                .setData("This is some invalid data")
+                .setContextId("context_id")
+                .setAttempt(1)
+                .build();
+        return MessageBuilder
+                .withPayload(mockChsDelta)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "test")
+                .setHeader("PSC_DELTA_RETRY_COUNT", 1)
+                .build();
+    }
+
+    private PscDelta createPscDelta() {
+
+        Psc psc = new Psc();
+
+        psc.setCompanyNumber("00623672");
+        psc.setInternalId("5");
+        psc.setKind(Psc.KindEnum.SUPER_SECURE);
+        psc.setCeasedOn("20180201");
+
+        return new PscDelta().addPscsItem(psc);
+    }
+
+    private FullRecordCompanyPSCApi createFullRecordPsc() {
+        FullRecordCompanyPSCApi fullRecordCompanyPscApi = new FullRecordCompanyPSCApi();
+        ExternalData externalData = new ExternalData();
+        Data data = new Data();
+
+        externalData.setId("5");
+        externalData.setInternalId("5");
+        externalData.setNotificationId("5");
+        externalData.setCompanyNumber("00623672");
+
+        data.setCeasedOn(LocalDate.of(2018, 2, 1));
+        data.setKind("super-secure-person-with-significant-control");
+
+        externalData.setData(data);
+        fullRecordCompanyPscApi.setExternalData(externalData);
+
+        return fullRecordCompanyPscApi;
+    }
+
+    }

--- a/src/test/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImplTest.java
@@ -29,7 +29,7 @@ public class ApiClientServiceImplTest {
     private final String companyNumber = "test12345";
     private final String pscId = "testId123456";
 
-    private final String uri = "/company/%s/persons-with-significant-control/%s";
+    private final String uri = "/company/%s/persons-with-significant-control/%s/individual";
 
     private ApiClientServiceImpl apiClientService;
 

--- a/src/test/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImplTest.java
@@ -8,15 +8,12 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
-import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateNaturalDisqualificationUpsert;
 import uk.gov.companieshouse.api.handler.delta.pscfullrecord.request.PscFullRecordPut;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;

--- a/src/test/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/service/api/ApiClientServiceImplTest.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.psc.delta.service.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateNaturalDisqualificationUpsert;
+import uk.gov.companieshouse.api.handler.delta.pscfullrecord.request.PscFullRecordPut;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+public class ApiClientServiceImplTest {
+
+    private final String contextId = "testContext";
+    private final String companyNumber = "test12345";
+    private final String pscId = "testId123456";
+
+    private final String uri = "/company/%s/persons-with-significant-control/%s";
+
+    private ApiClientServiceImpl apiClientService;
+
+    @Mock
+    private Logger logger;
+
+    @BeforeEach
+    public void setUp(){
+        apiClientService = new ApiClientServiceImpl(logger);
+        ReflectionTestUtils.setField(apiClientService, "chsApiKey", "testKey");
+        ReflectionTestUtils.setField(apiClientService, "apiUrl", "http://localhost:8888");
+    }
+
+    @Test
+    public void returnOkResponseWhenValidPutRequestSentToApi(){
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        String expectedUri = String.format(uri, companyNumber, pscId);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PscFullRecordPut.class));
+
+        ApiResponse<Void> response = apiClientServiceSpy.putPscFullRecord(contextId,
+                companyNumber,
+                pscId,
+                new FullRecordCompanyPSCApi());
+
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("putPscFullRecord"),
+                eq(expectedUri),
+                any(PscFullRecordPut.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/psc/delta/service/api/BaseApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/service/api/BaseApiClientServiceImplTest.java
@@ -1,0 +1,83 @@
+package uk.gov.companieshouse.psc.delta.service.api;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException.Builder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.Executor;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.psc.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.psc.delta.exception.RetryableErrorException;
+
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseApiClientServiceImplTest {
+
+    private BaseApiClientServiceImpl service;
+
+    @Mock
+    private Logger logger;
+    @Mock
+    private Executor executor;
+
+    @BeforeEach
+    void setup() {
+        service = new BaseApiClientServiceImpl(logger) {};
+    }
+
+    @Test
+    void returnsApiResponse() throws Exception {
+        ApiResponse expectedResponse = new ApiResponse(200, new HashMap<>());
+        when(executor.execute()).thenReturn(expectedResponse);
+
+        ApiResponse actualResponse = service.executeOp(null, null, null, executor);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void throwsRetryableErrorOn404() throws Exception {
+        when(executor.execute()).thenThrow(new URIValidationException("Not Found"));
+
+        RetryableErrorException thrown = assertThrows(RetryableErrorException.class,
+                () -> service.executeOp(null, null, null, executor));
+
+        assertThat(thrown.getMessage()).isEqualTo("404 NOT_FOUND response received from psc-data-api");
+    }
+
+    @Test
+    void throwsRetryableErrorOn500() throws Exception {
+        when(executor.execute()).thenThrow(
+                new ApiErrorResponseException(new Builder(500, "500", new HttpHeaders())));
+
+        RetryableErrorException thrown = assertThrows(RetryableErrorException.class,
+                () -> service.executeOp(null, null, null, executor));
+
+        assertThat(thrown.getMessage()).isEqualTo("Non-Successful response received from psc-data-api");
+    }
+
+    @Test
+    void throwsNonRetryableErrorOn400() throws Exception {
+        when(executor.execute()).thenThrow(
+                new ApiErrorResponseException(new Builder(400, "400", new HttpHeaders())));
+
+        NonRetryableErrorException thrown = assertThrows(NonRetryableErrorException.class,
+                () -> service.executeOp(null, null, null, executor));
+
+        assertThat(thrown.getMessage()).isEqualTo("400 BAD_REQUEST response received from psc-data-api");
+    }
+
+
+}

--- a/src/test/java/uk/gov/companieshouse/psc/delta/transformer/PscTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/transformer/PscTransformerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.psc.delta.transformer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -12,7 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import uk.gov.companieshouse.api.delta.Psc;
 import uk.gov.companieshouse.api.delta.PscDelta;
-import uk.gov.companieshouse.api.psc.ExternalData;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.psc.delta.mapper.PscMapper;
 
@@ -28,7 +26,6 @@ public class PscTransformerTest {
     @Mock
     private PscMapper pscMapper;
     private PscApiTransformer transformer;
-    private ExternalData externalData;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/resources/super-secure-psc-delta-example.json
+++ b/src/test/resources/super-secure-psc-delta-example.json
@@ -6,7 +6,5 @@
       "kind": "super-secure",
       "ceased_on": "20180201"
     }
-  ],
-  "CreatedTime": "28-APR-22 16.51.29.000000",
-  "delta_at": "20211029142043360560"
+  ]
 }


### PR DESCRIPTION
This pull request includes the mapper and transformer for converting a psc delta into a fullRecordCompanyPscApi object. Values from the delta are mapped to the fullRecordCompanyPscApi object in the mapper, which is used in the transformer. The delta processor was also added to process the ChsDelta payload.

This pull request also includes encoding the "psc_id", which is located in the MapperUtils class and is used in the mapper.

Unit tests were added for the transformer, mapper and processor.

Required for:

- DSND-1503