### PR TITLE
updated tests for super-secure to include psc_id

### DIFF
--- a/src/test/java/uk/gov/companieshouse/psc/delta/mapper/PscMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/mapper/PscMapperTest.java
@@ -201,6 +201,7 @@ public class PscMapperTest {
         links.add(linkTypes);
 
         assertEquals("lXgouUAR16hSIwxdJSpbr_dhyT8", externalData.getId());
+        assertEquals("AoRE4bhxdSdXur_NLdfh4JF81Y4", externalData.getPscId());
         assertEquals("5", externalData.getInternalId());
         assertEquals("lXgouUAR16hSIwxdJSpbr_dhyT8", externalData.getNotificationId());
         assertEquals("00623672", externalData.getCompanyNumber());

--- a/src/test/java/uk/gov/companieshouse/psc/delta/processor/PscDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/processor/PscDeltaProcessorTest.java
@@ -97,6 +97,7 @@ public class PscDeltaProcessorTest {
         Psc psc = new Psc();
 
         psc.setCompanyNumber("00623672");
+        psc.setPscId("3");
         psc.setInternalId("5");
         psc.setKind(Psc.KindEnum.SUPER_SECURE);
         psc.setCeasedOn("20180201");

--- a/src/test/resources/super-secure-psc-delta-example.json
+++ b/src/test/resources/super-secure-psc-delta-example.json
@@ -1,6 +1,7 @@
 {
   "pscs": [
     {
+      "psc_id": "3",
       "company_number": "00623672",
       "internal_id": "5",
       "kind": "super-secure",


### PR DESCRIPTION
Updated unit tests to include psc_id for super-secure pscs. This is because the psc_id is a required field in the psc delta.

Required for:
- DSND-1503