### PR TITLE
rework security-check to not purge, use parent-pom for version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 .PHONY: security-check
 security-check:
-	mvn org.owasp:dependency-check-maven:purge
+	mvn org.owasp:dependency-check-maven:update-only
 	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false
 
 .PHONY: build

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>1.3.0</version>
+        <version>2.1.4</version>
         <relativePath />
     </parent>
     <artifactId>psc-delta-consumer</artifactId>


### PR DESCRIPTION
reworks the dependency-check to not purge previous builds per advice: https://github.com/jeremylong/DependencyCheck#the-nvd-api-key-ci-and-rate-limiting

Also uses parent-pom to version dependency-check