### PR TITLE
DSND-3109: Add delta_at field to delete delta tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.4</version>
+        <version>2.1.6</version>
         <relativePath />
     </parent>
     <artifactId>psc-delta-consumer</artifactId>
@@ -27,7 +27,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.25</structured-logging.version>
         <kafka-models.version>1.0.34</kafka-models.version>
-        <private-api-sdk-java.version>2.0.421   </private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.443</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <map-struct.version>1.5.3.Final</map-struct.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>

--- a/src/itest/resources/json/input/psc_delete_delta.json
+++ b/src/itest/resources/json/input/psc_delete_delta.json
@@ -2,5 +2,6 @@
     "internal_id": "5",
     "company_number": "OE623672",
     "psc_id": "3",
-    "action": "DELETE"
+    "action": "DELETE",
+    "delta_at": "20230724093435661593"
   }

--- a/src/test/resources/psc-delete-delta-example.json
+++ b/src/test/resources/psc-delete-delta-example.json
@@ -2,5 +2,6 @@
     "internal_id": "5",
     "company_number": "00623672",
     "psc_id": "3",
-    "action": "DELETE"
+    "action": "DELETE",
+    "delta_at": "20230724093435661593"
   }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ