### PR TITLE
DSND-3113: Lenient changes for psc-delete-delta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.25</structured-logging.version>
         <kafka-models.version>1.0.34</kafka-models.version>
-        <private-api-sdk-java.version>2.0.446</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.459</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <map-struct.version>1.5.3.Final</map-struct.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>

--- a/src/itest/resources/json/input/psc_delete_delta.json
+++ b/src/itest/resources/json/input/psc_delete_delta.json
@@ -3,5 +3,6 @@
     "company_number": "OE623672",
     "psc_id": "3",
     "action": "DELETE",
+    "kind": "corporate-entity",
     "delta_at": "20230724093435661593"
   }

--- a/src/test/resources/psc-delete-delta-example.json
+++ b/src/test/resources/psc-delete-delta-example.json
@@ -3,5 +3,6 @@
     "company_number": "00623672",
     "psc_id": "3",
     "action": "DELETE",
+    "kind": "corporate-entity",
     "delta_at": "20230724093435661593"
   }


### PR DESCRIPTION
* Include psc kind in delete delta examples
* bump up sdk version to correct for lenient changes
* allows kind to be present within a psc-delete-delta but doesn't require it to be

[DSND-3113](https://companieshouse.atlassian.net/browse/DSND-3113)

[DSND-3113]: https://companieshouse.atlassian.net/browse/DSND-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ