### PR TITLE
DSND-2876: Revert Makefile change to `make test` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit: clean
-	mvn verify -Dskip.unit.tests=false -Dskip.integration.tests=false
+	mvn test
 
 .PHONY: test-integration
 test-integration: clean


### PR DESCRIPTION
* The `build-test-analyse` job has not been configured to run itests that use docker - . This then resulted in a failure after merging the previous Makefile change due to `make test-unit` also running itests.
* I have reverted this change and will raise a tech debt ticket to address this in `ci-pipelines`.

[DSND-2876](https://companieshouse.atlassian.net/browse/DSND-2876)

[DSND-2876]: https://companieshouse.atlassian.net/browse/DSND-2876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ