### PR TITLE
BI-15299 encode previous_psc_id

### DIFF
--- a/src/itest/resources/json/output/individual_with_previous_psc_id_psc_expected_output.json
+++ b/src/itest/resources/json/output/individual_with_previous_psc_id_psc_expected_output.json
@@ -10,7 +10,7 @@
     "psc_id": "AoRE4bhxdSdXur_NLdfh4JF81Y4",
     "notification_id": "lXgouUAR16hSIwxdJSpbr_dhyT8",
     "psc_statement_id": "UKWLhOXMpdjzt-Maq7hbxAyPyQs",
-    "previous_psc_id": "previous-psc-3",
+    "previous_psc_id": "ntEOdJKcNwLD0_-dnUEKVnGptbU",
     "company_name": "Test Company Ltd",
     "company_status": "active",
     "data": {

--- a/src/main/java/uk/gov/companieshouse/psc/delta/mapper/PscMapper.java
+++ b/src/main/java/uk/gov/companieshouse/psc/delta/mapper/PscMapper.java
@@ -35,7 +35,7 @@ public interface PscMapper {
     @Mapping(target = "externalData.internalId", source = "internalId")
     @Mapping(target = "externalData.notificationId", source = "internalId", ignore = true)
     @Mapping(target = "externalData.companyNumber", source = "companyNumber")
-    @Mapping(target = "externalData.previousPscId", source = "previousPscId")
+    @Mapping(target = "externalData.previousPscId", source = "previousPscId", ignore = true)
     @Mapping(target = "externalData.companyName", source = "companyName")
     @Mapping(target = "externalData.companyStatus", ignore = true)
     @Mapping(target = "externalData.id", source = "internalId", ignore = true)
@@ -288,6 +288,16 @@ public interface PscMapper {
     default void mapEncodedPscId(@MappingTarget ExternalData target, Psc source) {
         if (source.getPscId() != null) {
             target.setPscId(MapperUtils.encode(source.getPscId()));
+        }
+    }
+
+    /**
+     * encode previous_psc_id.
+     */
+    @AfterMapping
+    default void mapEncodedPreviousPscId(@MappingTarget ExternalData target, Psc source) {
+        if (source.getPreviousPscId() != null) {
+            target.setPreviousPscId(MapperUtils.encode(source.getPreviousPscId()));
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/psc/delta/mapper/PscMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/mapper/PscMapperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.psc.delta.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.companieshouse.api.delta.Psc.KindEnum.SUPER_SECURE;
@@ -73,7 +74,8 @@ class PscMapperTest {
         assertEquals("00623672", externalData.getCompanyNumber());
         assertEquals("Test Company Ltd", externalData.getCompanyName());
         assertEquals("active", externalData.getCompanyStatus());
-        assertEquals("previous-psc-3", externalData.getPreviousPscId());
+        assertEquals(MapperUtils.encode("previous-psc-3"), externalData.getPreviousPscId());
+        assertNotEquals("previous-psc-3", externalData.getPreviousPscId());
 
         assertEquals(LocalDate.of(2018, 2, 1), data.getCeasedOn());
         assertEquals("individual-person-with-significant-control", data.getKind());
@@ -120,6 +122,7 @@ class PscMapperTest {
         assertEquals("00623672", externalData.getCompanyNumber());
         assertEquals("Test Company Ltd", externalData.getCompanyName());
         assertEquals("active", externalData.getCompanyStatus());
+        assertNull(externalData.getPreviousPscId());
 
         // verify the identification object mapped into the Data object matches the expected identification
         assertEquals(createCorporateIdentification(), data.getIdentification());

--- a/src/test/java/uk/gov/companieshouse/psc/delta/mapper/PscMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/psc/delta/mapper/PscMapperTest.java
@@ -74,8 +74,7 @@ class PscMapperTest {
         assertEquals("00623672", externalData.getCompanyNumber());
         assertEquals("Test Company Ltd", externalData.getCompanyName());
         assertEquals("active", externalData.getCompanyStatus());
-        assertEquals(MapperUtils.encode("previous-psc-3"), externalData.getPreviousPscId());
-        assertNotEquals("previous-psc-3", externalData.getPreviousPscId());
+        assertPreviousPscIdIsEncoded(externalData);
 
         assertEquals(LocalDate.of(2018, 2, 1), data.getCeasedOn());
         assertEquals("individual-person-with-significant-control", data.getKind());
@@ -275,6 +274,11 @@ class PscMapperTest {
         assertEquals(Boolean.TRUE, sensitiveData.getResidentialAddressSameAsServiceAddress());
         assertEquals(dateOfBirth, sensitiveData.getDateOfBirth());
         assertEquals(internalId, sensitiveData.getInternalId().toString());
+    }
+
+    private void assertPreviousPscIdIsEncoded(ExternalData externalData) {
+        assertEquals(MapperUtils.encode("previous-psc-3"), externalData.getPreviousPscId());
+        assertNotEquals("previous-psc-3", externalData.getPreviousPscId());
     }
 
     Address createServiceAddress() {


### PR DESCRIPTION
## Brief description of the change(s)
>
> Encodes the previous_psc_id so that its encoded value is not exposed.



## Jira ticket
> https://companieshouse.atlassian.net/browse/BI-15299
